### PR TITLE
chore: split lint workflow into buf and Go code workflow

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -1,0 +1,34 @@
+name: buf.yaml
+on:
+  pull_request:
+    branches:
+      - main
+      - v2
+    paths:
+      - 'buf.yaml'
+      - 'buf.gen.yaml'
+      - 'proto/**'
+  push:
+    branches:
+      - main
+      - v2
+    paths:
+      - 'buf.yaml'
+      - 'buf.gen.yaml'
+      - 'buf/**'
+      - 'proto/**'
+
+jobs:
+  buf:
+    name: Run buf
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: bufbuild/buf-action@v1
+        with:
+          github_token: ${{ github.token }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,6 +9,7 @@ on:
       - '.run/**'
       - 'docs/**'
       - 'deployments/**'
+      - 'gen/**'
       - '*.md'
 
   pull_request:
@@ -20,6 +21,7 @@ on:
       - '.run/**'
       - 'docs/**'
       - 'deployments/**'
+      - 'gen/**'
       - '*.md'
 
 jobs:
@@ -40,17 +42,3 @@ jobs:
         with:
           version: v2.1
           args: --timeout=3m
-
-  buf:
-    name: Run buf
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - uses: bufbuild/buf-action@v1
-        with:
-          github_token: ${{ github.token }}


### PR DESCRIPTION
## Proposed changes

- Split lint workflow into separate lint workflow for buf and separate for go code; this is due to buf running unnecessarily every time

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/ChargePi/ChargePi-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...