### PR TITLE
fix: docker image bump to 1.25.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.24.0-bookworm AS base
+FROM --platform=$TARGETPLATFORM golang:1.25.0-bookworm AS base
 
 WORKDIR /ChargePi/src
 COPY . /ChargePi/src
@@ -39,7 +39,7 @@ RUN --mount=type=cache,target=/root/.npm npm install
 RUN npm run build
 
 # Test the client
-FROM --platform=$TARGETPLATFORM golang:1.24.0-bookworm AS test
+FROM --platform=$TARGETPLATFORM golang:1.25.0-bookworm AS test
 
 WORKDIR /ChargePi/src
 


### PR DESCRIPTION
## Proposed changes

- Bump Docker Go image to 1.25 to fix failing builds

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/ChargePi/ChargePi-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...